### PR TITLE
Report the sample rate to Honeycomb when sampling

### DIFF
--- a/telemetry.go
+++ b/telemetry.go
@@ -8,6 +8,7 @@ import (
 	hostMetrics "go.opentelemetry.io/contrib/instrumentation/host"
 	runtimeMetrics "go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -78,6 +79,7 @@ func newTraceProvider(exp *otlptrace.Exporter, sampleRate float64) *sdktrace.Tra
 	return sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
 		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(sampleRate))),
+		sdktrace.WithResource(resource.NewWithAttributes(semconv.SchemaURL, attribute.Key("SampleRate").Int64(int64(1.0/sampleRate)))),
 	)
 }
 


### PR DESCRIPTION
Honeycomb relies on an event attribute to re-multiply sampled events and display
correct (estimated) totals in response to queries.